### PR TITLE
Apply a fix for AutoGPTQ models

### DIFF
--- a/minigpt4_pipeline.py
+++ b/minigpt4_pipeline.py
@@ -33,7 +33,12 @@ class MiniGPT4_Pipeline(AbstractMultimodalPipeline):
 
     @staticmethod
     def embed_tokens(input_ids: torch.Tensor) -> torch.Tensor:
-        return shared.model.model.embed_tokens(input_ids).to(shared.model.device, dtype=shared.model.dtype)
+        if hasattr(shared.model.model, 'embed_tokens'):
+            func = shared.model.model.embed_tokens
+        else:
+            func = shared.model.model.model.embed_tokens  # AutoGPTQ case
+
+        return func(input_ids).to(shared.model.device, dtype=shared.model.dtype)
 
     @staticmethod
     def placeholder_embeddings() -> torch.Tensor:


### PR DESCRIPTION
This fix is necessary for GPTQ models loaded through AutoGPTQ (the current default in text-generation-webui)